### PR TITLE
Listener on size_allocate (issues on wide panels)

### DIFF
--- a/mate-panel/panel-action-button.c
+++ b/mate-panel/panel-action-button.c
@@ -708,6 +708,51 @@ panel_action_button_style_updated (PanelActionButton *button)
 }
 
 static void
+panel_action_button_size_reallocate(GtkWidget *widget, GtkAllocation *allocation, gpointer data) {
+  
+  	PanelWidget *panel = (PanelWidget *) data;
+  	PanelActionButton *button =  (PanelActionButton *) widget;
+  	gboolean change = FALSE;
+
+	if (panel->orient == GTK_ORIENTATION_HORIZONTAL) {
+	
+		if ( allocation->height > 50 ) {
+
+			int ratio = allocation->width / allocation->height;
+			allocation->width = 50;	
+			gtk_widget_size_allocate (GTK_WIDGET (button), allocation);
+			change = TRUE;
+		}
+	
+	} else {
+	
+		if ( allocation->width > 50 ) {
+
+			int ratio = allocation->width / allocation->height;
+			allocation->height = 50;	
+			gtk_widget_size_allocate (GTK_WIDGET (button), allocation);
+			change = TRUE;
+		}
+	
+	
+	}
+
+	/*
+	* The above code works and resizes the buttons when width or height is too big
+	* But the resize is somehow on the button and not the applet itself (or the gap is kept somewhere else?)
+	* The below code was a try to resize the applet, but it doesn't change anything
+	* TODO: I don't know how to trigger changes in size of the applet directly?
+	*/
+	if ( change == TRUE ) {
+
+		size_change (button->priv->info, panel);
+		back_change (button->priv->info, panel);
+
+	}
+
+}
+
+static void
 panel_action_button_load (PanelActionButtonType  type,
 			  PanelWidget           *panel,
 			  gboolean               locked,
@@ -739,6 +784,9 @@ panel_action_button_load (PanelActionButtonType  type,
 
 	panel_widget_set_applet_expandable (panel, GTK_WIDGET (button), FALSE, TRUE);
 	panel_widget_set_applet_size_constrained (panel, GTK_WIDGET (button), TRUE);
+
+	/* change the size if too big */
+	g_signal_connect(GTK_WIDGET (button), "size-allocate", G_CALLBACK(panel_action_button_size_reallocate), panel);
 
 	if (actions [button->priv->type].setup_menu)
 		actions [button->priv->type].setup_menu (button);


### PR DESCRIPTION
The problem is that if the panel is too wide or high, for example 150px high. An action button will allocate a size of 150x150 for that button.. It could let the icon size at a smaller size (for example 40) and only allocate 150 height (normal height of panel) and only 40px width.
The following code tries to do that. It works vertically and horizontally. But..
The listener gets the definite allocated size to check if it is too wide or high (for wide panels) and limits the size of the action button to a fixed limit (here 50 pixels). In the future I would like to set that limit as an option in the parameters of the panel itself and then all other applets can refer to the same user defined size. We will need to add a gsettings change listener also for that.
But for the moment it doesn't yet completely work, the button is resized, but not the applet that contains the button apparently, I can't figure out which widget must be further affected, some configuration in the panel keeps the empty space (and prevents moving other applets there) even though the applet is correctly restricted in size.