### PR TITLE
Fix wide panels sizes (vert/horz)

### DIFF
--- a/mate-panel/button-widget.c
+++ b/mate-panel/button-widget.c
@@ -446,9 +446,14 @@ button_widget_get_preferred_width (GtkWidget *widget,
 
 	parent = gtk_widget_get_parent (widget);
 
-	if (button_widget->priv->orientation & PANEL_HORIZONTAL_MASK)
+	if (button_widget->priv->orientation & PANEL_HORIZONTAL_MASK){
 		size = gtk_widget_get_allocated_height (parent);
-	else
+
+		/* should get this value (50) from gsettings, user defined value in properties of the panel (max_icon_size) OR use 48*/
+		if ( size > 50 )
+			size = 50;	
+
+	} else
 		size = gtk_widget_get_allocated_width (parent);
 
 	*minimal_width = *natural_width = size;
@@ -467,8 +472,14 @@ button_widget_get_preferred_height (GtkWidget *widget,
 
 	if (button_widget->priv->orientation & PANEL_HORIZONTAL_MASK)
 		size = gtk_widget_get_allocated_height (parent);
-	else
+	else {
 		size = gtk_widget_get_allocated_width (parent);
+		
+		/* should get this value (50) from gsettings, user defined value in properties of the panel (max_icon_size) OR use 48*/
+		if ( size > 50 )
+			size = 50;	
+	
+	}
 
 	*minimal_height = *natural_height = size;
 }
@@ -480,6 +491,17 @@ button_widget_size_allocate (GtkWidget     *widget,
 	ButtonWidget *button_widget = BUTTON_WIDGET (widget);
 	int           size;
 
+	/* should get this value (50) from gsettings, user defined value in properties of the panel (max_icon_size) OR use 48?*/
+	if (button_widget->priv->orientation & PANEL_HORIZONTAL_MASK) {
+		if ( allocation->height > 50 ) {
+			allocation->width = 50;	
+		}
+	} else {
+		if ( allocation->width > 50 ) {
+			allocation->height = 50;	
+		}
+	}
+	
 	GTK_WIDGET_CLASS (button_widget_parent_class)->size_allocate (widget, allocation);
 
 	if (button_widget->priv->orientation & PANEL_HORIZONTAL_MASK)


### PR DESCRIPTION
This change limits the size taken by all BUTTON_WIDGETs when the panel is wide, because for the moment when for example the panel is horizontal 200 pixels wide/high, the widgets take up 200x200 for an icon of max size 48.
I've set it to take now (for this example) 50x200 or 200x50 (if it's a vertical panel 200px wide)
If users want to leave the same space as before around the icons they just have to move them on the panel anyway and it can be as before..
What I'd like to add after is to get this size (48 or 50) from gsettings by a new option set in the panel properties as 'max_icon_size' or something like that, so that the user decides on the maximum icon size him/herself.

It still needs some work, the arrow for menus is not updated to correct size yet...

![changes](https://user-images.githubusercontent.com/13189097/44319716-d4813d00-a43d-11e8-9ca5-7817ba276244.png)